### PR TITLE
change page size from 10 to 100 to allow bridge to handle more than 10 devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ somewhat hacked together for now, please excuse the hard coded values
 
 grab the jar, run like this:
 ```
-java -jar amazon-echo-bridge-0.1.0.jar --upnp.config.address=192.168.1.240
+java -jar amazon-echo-bridge-0.1.0.jar --upnp.config.address=192.168.1.240 --vera.ip.address=192.168.1.3
 ```
-replace the --upnp.config.address value with the server ipv4 address.  To force ipv4 in java you can add the system property -Djava.net.preferIPv4Stack=true
+replace the --upnp.config.address value with the server ipv4 address and --vera.ip.address value with your Vera IP to enable auto configuration on startup
+
+To force ipv4 in java you can add the system property -Djava.net.preferIPv4Stack=true
+

--- a/src/main/java/com/armzilla/ha/dao/DeviceRepository.java
+++ b/src/main/java/com/armzilla/ha/dao/DeviceRepository.java
@@ -1,5 +1,8 @@
 package com.armzilla.ha.dao;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 import java.util.List;
@@ -8,7 +11,7 @@ import java.util.List;
  * Created by arm on 4/13/15.
  */
 public interface DeviceRepository extends ElasticsearchRepository<DeviceDescriptor, String> {
-    List<DeviceDescriptor> findByDeviceType(String type);
+    Page<DeviceDescriptor> findByDeviceType(String type, Pageable request);
     List<DeviceDescriptor> findAll();
     DeviceDescriptor findOne(String id);
 

--- a/src/main/java/com/armzilla/ha/devicemanagmeent/DeviceResource.java
+++ b/src/main/java/com/armzilla/ha/devicemanagmeent/DeviceResource.java
@@ -44,7 +44,7 @@ public class DeviceResource {
     private String veraIP;
 
 
-  //  @PostConstruct
+    @PostConstruct
     @RequestMapping(method = RequestMethod.GET, produces = "application/json", headers = "Accept=application/json", value = "/autoconfigureFromVera")
     public List<DeviceDescriptor> autoconfigureFromVera() throws IOException {
         CloseableHttpClient httpclient = HttpClients.createDefault();

--- a/src/main/java/com/armzilla/ha/devicemanagmeent/DeviceResource.java
+++ b/src/main/java/com/armzilla/ha/devicemanagmeent/DeviceResource.java
@@ -3,7 +3,16 @@ package com.armzilla.ha.devicemanagmeent;
 import com.armzilla.ha.api.Device;
 import com.armzilla.ha.dao.DeviceDescriptor;
 import com.armzilla.ha.dao.DeviceRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -12,6 +21,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.text.MessageFormat;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -22,9 +34,44 @@ import java.util.UUID;
 @Controller
 @RequestMapping("/api/devices")
 public class DeviceResource {
+    Log log = LogFactory.getLog(DeviceResource.class);
 
     @Autowired
     private DeviceRepository deviceRepository;
+
+
+    @Value("${vera.ip.address}")
+    private String veraIP;
+
+
+    @PostConstruct
+    @RequestMapping(method = RequestMethod.GET, produces = "application/json", headers = "Accept=application/json", value = "/autoconfigureFromVera")
+    public List<DeviceDescriptor> autoconfigureFromVera() throws IOException {
+        CloseableHttpClient httpclient = HttpClients.createDefault();
+        HttpGet httpGet = new HttpGet(MessageFormat.format("http://{0}:3480/data_request?id=user_data&output_format=json", this.veraIP));
+        ObjectMapper mapper = new ObjectMapper();
+        try (CloseableHttpResponse response1 = httpclient.execute(httpGet)) {
+            JsonNode json = mapper.readTree(response1.getEntity().getContent());
+            JsonNode devices = json.get("devices");
+            for (JsonNode deviceNode : devices) {
+                String name = deviceNode.get("name").asText();
+                String deviceType = deviceNode.get("device_type").asText();
+                if (deviceType.equals("urn:schemas-upnp-org:device:BinaryLight:1")) {
+                    log.debug("Adding:"+name);
+                    DeviceDescriptor deviceEntry = new DeviceDescriptor();
+                    String deviceId = deviceNode.get("id").asText();
+                    deviceEntry.setId(deviceId);
+                    deviceEntry.setName(name);
+                    deviceEntry.setDeviceType("switch");
+                    deviceEntry.setOnUrl(MessageFormat.format("http://{0}:3480/data_request?id=action&output_format=json&serviceId=urn:upnp-org:serviceId:SwitchPower1&action=SetTarget&newTargetValue=1&DeviceNum={1}", veraIP, deviceId));
+                    deviceEntry.setOffUrl(MessageFormat.format("http://{0}:3480/data_request?id=action&output_format=json&serviceId=urn:upnp-org:serviceId:SwitchPower1&action=SetTarget&newTargetValue=0&DeviceNum={1}", veraIP, deviceId));
+                    deviceRepository.save(deviceEntry);
+                }
+            }
+        }
+        return deviceRepository.findAll();
+    }
+
 
     @RequestMapping(method = RequestMethod.POST, produces = "application/json", headers = "Accept=application/json")
     public ResponseEntity<DeviceDescriptor> createDevice(@RequestBody Device device) {
@@ -48,18 +95,18 @@ public class DeviceResource {
     }
 
     @RequestMapping(value = "/{lightId}", method = RequestMethod.GET, produces = "application/json")
-    public ResponseEntity<DeviceDescriptor> findByDevicId(@PathVariable("lightId") String id){
+    public ResponseEntity<DeviceDescriptor> findByDevicId(@PathVariable("lightId") String id) {
         DeviceDescriptor descriptor = deviceRepository.findOne(id);
-        if(descriptor == null){
+        if (descriptor == null) {
             return new ResponseEntity<>(null, null, HttpStatus.NOT_FOUND);
         }
         return new ResponseEntity<>(descriptor, null, HttpStatus.OK);
     }
 
     @RequestMapping(value = "/{lightId}", method = RequestMethod.DELETE, produces = "application/json")
-    public ResponseEntity<String> deleteDeviceById(@PathVariable("lightId") String id){
+    public ResponseEntity<String> deleteDeviceById(@PathVariable("lightId") String id) {
         DeviceDescriptor deleted = deviceRepository.findOne(id);
-        if(deleted == null){
+        if (deleted == null) {
             return new ResponseEntity<>(null, null, HttpStatus.NOT_FOUND);
         }
         deviceRepository.delete(deleted);

--- a/src/main/java/com/armzilla/ha/devicemanagmeent/DeviceResource.java
+++ b/src/main/java/com/armzilla/ha/devicemanagmeent/DeviceResource.java
@@ -44,7 +44,7 @@ public class DeviceResource {
     private String veraIP;
 
 
-    @PostConstruct
+  //  @PostConstruct
     @RequestMapping(method = RequestMethod.GET, produces = "application/json", headers = "Accept=application/json", value = "/autoconfigureFromVera")
     public List<DeviceDescriptor> autoconfigureFromVera() throws IOException {
         CloseableHttpClient httpclient = HttpClients.createDefault();

--- a/src/main/java/com/armzilla/ha/hue/HueMulator.java
+++ b/src/main/java/com/armzilla/ha/hue/HueMulator.java
@@ -10,6 +10,8 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -45,7 +47,7 @@ public class HueMulator {
     @RequestMapping(value = "/{userId}/lights", method = RequestMethod.GET, produces = "application/json")
     public ResponseEntity<Map<String, String>> getUpnpConfiguration(@PathVariable(value = "userId") String userId, HttpServletRequest request) {
         log.info("hue lights list requested: " + userId + " from " + request.getRemoteAddr());
-        List<DeviceDescriptor> deviceList = repository.findByDeviceType("switch");
+        Page<DeviceDescriptor> deviceList = repository.findByDeviceType("switch", new PageRequest(0,100));
         Map<String, String> deviceResponseMap = new HashMap<>();
         for (DeviceDescriptor device : deviceList) {
             deviceResponseMap.put(device.getId(), device.getName());
@@ -56,7 +58,7 @@ public class HueMulator {
     @RequestMapping(value = "/{userId}", method = RequestMethod.GET, produces = "application/json")
     public ResponseEntity<HueApiResponse> getApi(@PathVariable(value = "userId") String userId, HttpServletRequest request) {
         log.info("hue api root requested: " + userId + " from " + request.getRemoteAddr());
-        List<DeviceDescriptor> descriptorList = repository.findByDeviceType("switch");
+        Page<DeviceDescriptor> descriptorList = repository.findByDeviceType("switch", new PageRequest(0, 100));
         if (descriptorList == null) {
             return new ResponseEntity<>(null, null, HttpStatus.NOT_FOUND);
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 upnp.response.port=50000
 server.port=8080
-upnp.config.address=192.168.1.22
+upnp.config.address=192.168.1.9
+vera.ip.address=192.168.1.3


### PR DESCRIPTION
Because of the default page size = 10 findByDeviceType only returns first 10 configured devices, so bridge is unable to handle more then 10 devices irregardless of a number of devices configured. I upped this limit to 100 which should be plenty for most Vera installs. 