### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM maven
+
+WORKDIR /root
+COPY pom.xml /root/pom.xml
+COPY src /root/src
+
+RUN mvn install
+
+EXPOSE 8080
+
+CMD ["bash", "-c", "java -jar target/amazon-echo-bridge-0.2.0.jar --upnp.config.address=$(ip route get 8.8.8.8 | egrep -o '[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\s*$')"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
 emulates philips hue api to other home automation gateways.  The Amazon echo now supports wemo and philip hue... great news if you own any of those devices!
 My house is pretty heavily invested in the z-wave using the Vera as the gateway and thought it would be nice bridge the Amazon Echo to it.
 
+Run (with docker)
+-----------------
+```bash
+docker build -t amazon-echo-ha-bridge .
+docker run -ti --rm --net=host amazon-echo-ha-bridge
+```
+
 Run
 ---
 To run the pre-built jar using maven:


### PR DESCRIPTION
This enables automatically building and running the proxy in a Docker
container. A nice option for people who don't want to fuss with getting
Java and Maven installed.