### PR TITLE
Adds option to disable upnp listener

### DIFF
--- a/src/main/java/com/armzilla/ha/upnp/UpnpListener.java
+++ b/src/main/java/com/armzilla/ha/upnp/UpnpListener.java
@@ -32,11 +32,19 @@ public class UpnpListener {
 	@Value("${upnp.config.address}")
 	private String responseAddress;
 
+	@Value("${upnp.disable}")
+	private boolean disable;
+
 	@Autowired
 	private ApplicationContext applicationContext;
 
 	@Scheduled(fixedDelay = Integer.MAX_VALUE)
 	public void startListening(){
+
+		if (disable)  {
+			return;
+		}
+		
 		log.info("Starting UPNP Discovery Listener");
 
 		try (DatagramSocket responseSocket = new DatagramSocket(upnpResponsePort);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 upnp.response.port=50000
 server.port=8080
 upnp.config.address=192.168.1.1
+upnp.disable=false


### PR DESCRIPTION
This is needed so the echo does not discover devices when you don't tell it to. If the upnp listener is always on, then the echo refreshes the device list without your approval.

This is also useful if you want to run multiple ha-bridges on one server, like:

```
java -jar C:\dir1\amazon-echo-bridge-0.2.1.jar --upnp.config.address=192.168.1.110 --server.port=8080 --upnp.response.port=50000 --upnp.disable=true

java -jar C:\dir2\amazon-echo-bridge-0.2.1.jar --upnp.config.address=192.168.1.110 --server.port=8081 --upnp.response.port=50001 --upnp.disable=true
```
